### PR TITLE
feat(auth): support username login

### DIFF
--- a/src/@auth/authJs.ts
+++ b/src/@auth/authJs.ts
@@ -9,31 +9,54 @@ import type { NextAuthConfig } from 'next-auth';
  */
 const authConfig: NextAuthConfig = {
 	providers: [
-		Credentials({
-			name: 'Credentials',
-			credentials: {
-				email: { label: 'Email', type: 'text' },
-				password: { label: 'Password', type: 'password' }
-			},
-			async authorize(credentials) {
-				if (!credentials?.email) {
-					return null;
-				}
+                Credentials({
+                        name: 'Credentials',
+                        credentials: {
+                                username: { label: 'Username', type: 'text' },
+                                password: { label: 'Password', type: 'password' }
+                        },
+                        async authorize(credentials) {
+                                if (!credentials?.username) {
+                                        return null;
+                                }
 
-				return {
-					id: 1,
-					username: credentials.email,
-					nama_lengkap: credentials.email,
-					role: 'user'
-				} as {
-					id: number;
-					username: string;
-					nama_lengkap: string;
-					role: string;
-				};
-			}
-		})
-	],
+                                try {
+                                        const response = await fetch('http://127.0.0.1:8000/api/login', {
+                                                method: 'POST',
+                                                headers: {
+                                                        'Content-Type': 'application/json'
+                                                },
+                                                body: JSON.stringify({
+                                                        username: credentials.username,
+                                                        password: credentials.password,
+                                                        akses_modul: 0
+                                                })
+                                        });
+
+                                        if (!response.ok) {
+                                                return null;
+                                        }
+
+                                        const data = await response.json();
+                                        const user = data.user ?? data;
+
+                                        return {
+                                                id: user.id,
+                                                username: user.username,
+                                                nama_lengkap: user.nama_lengkap ?? user.username,
+                                                role: user.role ?? 'user'
+                                        } as {
+                                                id: number;
+                                                username: string;
+                                                nama_lengkap: string;
+                                                role: string;
+                                        };
+                                } catch (error) {
+                                        return null;
+                                }
+                        }
+                })
+        ],
 	session: {
 		strategy: 'jwt'
 	}

--- a/src/@auth/forms/AuthJsCredentialsSignInForm.tsx
+++ b/src/@auth/forms/AuthJsCredentialsSignInForm.tsx
@@ -17,23 +17,23 @@ import signinErrors from './signinErrors';
  * Form Validation Schema
  */
 const schema = z.object({
-	email: z.string().email('You must enter a valid email').nonempty('You must enter an email'),
-	password: z
-		.string()
-		.min(4, 'Password is too short - must be at least 4 chars.')
-		.nonempty('Please enter your password.')
+        username: z.string().nonempty('You must enter a username'),
+        password: z
+                .string()
+                .min(4, 'Password is too short - must be at least 4 chars.')
+                .nonempty('Please enter your password.')
 });
 
 type FormType = {
-	email: string;
-	password: string;
-	remember?: boolean;
+        username: string;
+        password: string;
+        remember?: boolean;
 };
 
 const defaultValues = {
-	email: '',
-	password: '',
-	remember: true
+        username: '',
+        password: '',
+        remember: true
 };
 
 function AuthJsCredentialsSignInForm() {
@@ -45,26 +45,26 @@ function AuthJsCredentialsSignInForm() {
 
 	const { isValid, dirtyFields, errors } = formState;
 
-	useEffect(() => {
-		setValue('email', 'admin@fusetheme.com', {
-			shouldDirty: true,
-			shouldValidate: true
-		});
-		setValue('password', '5;4+0IOx:\\Dy', {
-			shouldDirty: true,
-			shouldValidate: true
-		});
-	}, [setValue]);
+        useEffect(() => {
+                setValue('username', 'admin', {
+                        shouldDirty: true,
+                        shouldValidate: true
+                });
+                setValue('password', '5;4+0IOx:\\Dy', {
+                        shouldDirty: true,
+                        shouldValidate: true
+                });
+        }, [setValue]);
 
-	async function onSubmit(formData: FormType) {
-		const { email, password } = formData;
+        async function onSubmit(formData: FormType) {
+                const { username, password } = formData;
 
-		const result = await signIn('credentials', {
-			email,
-			password,
-			formType: 'signin',
-			redirect: false
-		});
+                const result = await signIn('credentials', {
+                        username,
+                        password,
+                        formType: 'signin',
+                        redirect: false
+                });
 
 		if (result?.error) {
 			setError('root', { type: 'manual', message: signinErrors[result.error] });
@@ -93,24 +93,24 @@ function AuthJsCredentialsSignInForm() {
 					{errors?.root?.message}
 				</Alert>
 			)}
-			<Controller
-				name="email"
-				control={control}
-				render={({ field }) => (
-					<TextField
-						{...field}
-						className="mb-6"
-						label="Email"
-						autoFocus
-						type="email"
-						error={!!errors.email}
-						helperText={errors?.email?.message}
-						variant="outlined"
-						required
-						fullWidth
-					/>
-				)}
-			/>
+                        <Controller
+                                name="username"
+                                control={control}
+                                render={({ field }) => (
+                                        <TextField
+                                                {...field}
+                                                className="mb-6"
+                                                label="Username"
+                                                autoFocus
+                                                type="text"
+                                                error={!!errors.username}
+                                                helperText={errors?.username?.message}
+                                                variant="outlined"
+                                                required
+                                                fullWidth
+                                        />
+                                )}
+                        />
 			<Controller
 				name="password"
 				control={control}


### PR DESCRIPTION
## Summary
- switch credential auth to username/password and call backend login API
- update sign-in form to request username instead of email

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689987f1947883299f8c6e7b3d832034